### PR TITLE
20240228 fixes

### DIFF
--- a/bin/loq_by_cv.py
+++ b/bin/loq_by_cv.py
@@ -5,7 +5,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from tqdm import tqdm
 import argparse
-plt.style.use('seaborn-whitegrid')
+plt.style.use('seaborn-v0_8-whitegrid')
 
 # detect whether the file is Encyclopedia output or Skyline report, then read it in appropriately
 def read_input(filename, col_conc_map_file):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas
+tqdm
+lmfit
+numpy
+matplotlib
+seaborn
+pyarrow


### PR DESCRIPTION
1. Updated references to `seaborn-whitegrid` to `seaborn-v0_8-whitegrid`.
2. Using `append` to append to a Pandas data frame is deprecated. Updated to using Pandas `concat` function.
3. When bootstrapping resampled the calibration points, it would occasionally choose the same point every time, which caused a runtime error. Updated to re-run the resampling until at least 2 unique points were chosen.
4. Added requirements.txt, which I think represents the required Python libraries. 
