### PR TITLE
Allow configuring the minimum number of noise/linear points required for fit

### DIFF
--- a/bin/calculate-loq.py
+++ b/bin/calculate-loq.py
@@ -11,11 +11,10 @@ import random
 from lmfit import Minimizer, Parameters
 from lmfit.models import LinearModel
 
-plt.style.use('seaborn-v0_8-whitegrid')
 DEFAULT_MIN_LINEAR_POINTS = 1
 DEFAULT_MIN_NOISE_POINTS = 2
 
-plt.style.use('seaborn-whitegrid')
+plt.style.use('seaborn-v0_8-whitegrid')
 
 np.random.seed(8888)
 random.seed(8888)

--- a/bin/calculate-loq.py
+++ b/bin/calculate-loq.py
@@ -187,7 +187,7 @@ def calculate_lod(model_params, df, std_mult, min_noise_points, min_linear_point
 
     std_noise = np.std(df['area'].loc[(df['curvepoint'].astype(float) < intersection)])
 
-    min_curvepoint = df["curvepoint"].min()
+    min_curvepoint = df["curvepoint"].astype(float).min()
     if intersection <= min_curvepoint and min_noise_points < 1:
         LOD = min_curvepoint
         std_noise = np.nan
@@ -198,7 +198,7 @@ def calculate_lod(model_params, df, std_mult, min_noise_points, min_linear_point
     lod_results = [LOD, std_noise]
 
     # LOD edge cases
-    mask = df["curvepoint"] >= LOD
+    mask = df["curvepoint"].astype(float) >= LOD
     if df["curvepoint"][mask].nunique() < min_linear_points:
         # if the intersection is higher than the top point of the curve
         lod_results = [np.inf, np.inf]


### PR DESCRIPTION
In some cases it may be desirable or necessary to use stricter (or relaxed) thresholds for the number of points in the noise/linear range. This PR adds CLI parameters for these values.