### PR TITLE
Bug Fixes, Performance, and Pandas 2.x Compatibility for LOD/LOQ Scripts

### DIFF
--- a/bin/calculate-loq.py
+++ b/bin/calculate-loq.py
@@ -6,7 +6,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from tqdm import tqdm
 import argparse
-import random
 from lmfit import Minimizer, Parameters
 from lmfit.models import LinearModel
 
@@ -15,8 +14,11 @@ DEFAULT_MIN_NOISE_POINTS = 2
 
 plt.style.use('seaborn-v0_8-whitegrid')
 
-np.random.seed(8888)
-random.seed(8888)
+# Note: global np.random.seed removed; each bootstrap replicate uses an
+# independent SeedSequence for thread-safe, reproducible resampling.
+# Note: std_noise in calculate_lod uses ddof=1 (sample std, Bessel-corrected).
+# np.std() defaults to ddof=0; ddof=1 is analytically correct for estimating
+# a population noise parameter from a small sample (consistent with loq_by_cv.py).
 
 # Force warnings (other than FutureWarning) to kill the script; this allows debugging numpy warnings.
 #import warnings
@@ -26,7 +28,33 @@ random.seed(8888)
 
 # Assume input file source, read in the data, and return a standard-format melted dataframe
 # output of this function is a melted dataframe with columns: peptide, curvepoint, area
+def _validate_conc_map(col_conc_map_file):
+    """Warn if the concentration map is empty or contains unannotated rows."""
+    try:
+        _map = pd.read_csv(col_conc_map_file)
+    except Exception:
+        return  # let the main read raise its own error
+    if _map.empty or 'concentration' not in _map.columns:
+        sys.stderr.write(
+            'WARNING: the concentration map appears to be blank or is missing '
+            'a "concentration" column. No curve points will be mapped.\n'
+        )
+        return
+    blank = _map['concentration'].isna() | (_map['concentration'].astype(str).str.strip() == '')
+    n_blank = int(blank.sum())
+    if n_blank:
+        sys.stderr.write(
+            f'WARNING: {n_blank} row(s) in the concentration map have a blank/unannotated '
+            f'concentration value and will be skipped:\n'
+        )
+        fname_col = 'filename' if 'filename' in _map.columns else _map.columns[0]
+        for fname in _map.loc[blank, fname_col].tolist():
+            sys.stderr.write(f'  {fname}\n')
+
+
 def read_input(filename, col_conc_map_file):
+    _validate_conc_map(col_conc_map_file)
+
     with open(filename, 'r') as f:
         header_line = f.readline()
 
@@ -73,7 +101,7 @@ def read_input(filename, col_conc_map_file):
         df_melted['curvepoint'].replace('', np.nan, inplace=True)
         df_melted.dropna(subset=['curvepoint'], inplace=True)
 
-        df_melted['area'].fillna(0, inplace=True)  # replace NA with 0
+        df_melted['area'] = df_melted['area'].fillna(0)  # replace NA with 0
 
     # If dia-nn *.pr_matrix.tsv input file, supply warning about normalizations 
     # and suggest using diann_report.tsv instead
@@ -309,7 +337,7 @@ def calculate_lod(model_params, df, std_mult, min_noise_points, min_linear_point
 
         # calculate the standard deviation for the noise segment
         intersection = (b_linear-b_noise) / (m_noise-m_linear)
-        std_noise = np.std(df['area'].loc[(df['curvepoint'].astype(float) < intersection)])
+        std_noise = np.std(df['area'].loc[(df['curvepoint'].astype(float) < intersection)], ddof=1)  # sample std (Bessel-corrected)
 
         if m_linear < 0:  # catch edge cases where there is only noise in the curve
             LOD = float('Inf')
@@ -334,7 +362,7 @@ def calculate_lod(model_params, df, std_mult, min_noise_points, min_linear_point
     else:
         intersection = (b_linear-b_noise) / (m_noise-m_linear)
 
-    std_noise = np.std(df['area'].loc[(df['curvepoint'].astype(float) < intersection)])
+    std_noise = np.std(df['area'].loc[(df['curvepoint'].astype(float) < intersection)], ddof=1)  # sample std (Bessel-corrected)
 
     min_curvepoint = df["curvepoint"].astype(float).min()
     if intersection <= min_curvepoint and min_noise_points < 1:
@@ -377,13 +405,8 @@ def calculate_loq(model_params, boot_results, cv_thresh=0.2):
         if 0 == good_cv.sum():
             LOQ = float('Inf')
         else:
-            # LOQ is the larger of:
-            #   - smallest intensity with good CV
-            #   - largest intensity with bad CV
-            LOQ = max(
-                boot_subset[good_cv]['boot_x'].min(),
-                boot_subset[~good_cv]['boot_x'].max()
-            )
+            # LOQ is the lowest concentration at which CV < threshold
+            LOQ = boot_subset[good_cv]['boot_x'].min()
 
             # LOQ edge cases
             if LOQ >= boot_results['boot_x'].max() or LOQ <= 0:
@@ -392,31 +415,28 @@ def calculate_loq(model_params, boot_results, cv_thresh=0.2):
     return LOQ
 
 
+# Module-level function so it can be referenced by bootstrap_many.
+# Uses a per-replicate SeedSequence for thread-safe, reproducible resampling.
+def _bootstrap_once(df, new_x, seed, model="auto"):
+    rng = np.random.default_rng(np.random.SeedSequence(seed))
+    while True:
+        resampled_df = df.sample(n=len(df), replace=True, random_state=rng)
+        if resampled_df['area'].nunique() > 1:
+            break
+
+    boot_x = np.array(resampled_df['curvepoint'], dtype=float)
+    boot_y = np.array(resampled_df['area'], dtype=float)
+    fit_result, mini_result = fit_by_lmfit_yang(boot_x, boot_y, model)
+
+    a = fit_result.params['a'].value
+    b = fit_result.params['b'].value
+    c = fit_result.params['c'].value
+
+    return np.maximum(new_x * a + b, c)
+
+
 # determine prediction interval by bootstrapping
 def bootstrap_many(df, new_x, num_bootreps=100, model="auto"):
-
-    def bootstrap_once(df, new_x, iter_num, model="auto"):
-
-#        resampled_df = df.sample(n=len(df), replace=True)
-
-        while True:
-            resampled_df = df.sample(n=len(df), replace=True)
-            if resampled_df['area'].nunique() > 1:
-                break
-
-        boot_x = np.array(resampled_df['curvepoint'], dtype=float)
-        boot_y = np.array(resampled_df['area'], dtype=float)
-        fit_result, mini_result = fit_by_lmfit_yang(boot_x, boot_y, model)
-
-        a = fit_result.params['a'].value
-        b = fit_result.params['b'].value
-        c = fit_result.params['c'].value
-
-        yresults = np.maximum(new_x * a + b, c)
-
-        iter_results = pd.DataFrame(data={'boot_x': new_x, iter_num: yresults})
-
-        return iter_results
 
     if df.empty or np.isnan(new_x).any():
         boot_summary = pd.DataFrame(columns=['boot_x', 'count', 'mean', 'std', 'min',
@@ -424,20 +444,23 @@ def bootstrap_many(df, new_x, num_bootreps=100, model="auto"):
 
     else:
         # Bootstrap the data (e.g. resample the data with replacement), eval prediction (new_y) at each new_x
-        boot_results = pd.DataFrame(data={'boot_x': new_x})
-        for i in range(num_bootreps):
-            iteration_results = bootstrap_once(df, new_x, i, model)
+        rows = [_bootstrap_once(df, new_x, i, model) for i in range(num_bootreps)]
 
-            boot_results = pd.merge(boot_results, iteration_results, on='boot_x')
+        # reshape the bootstrap results: rows=replicates, columns=x-grid points
+        mat = np.vstack(rows)   # shape (num_bootreps, len(new_x))
 
-        # reshape the bootstrap results to be columns=boot_x and rows=boot_y results (each iteration is a row)
-        boot_results = boot_results.T
-        boot_results.columns = boot_results.iloc[0]
-        boot_results = boot_results.drop(['boot_x'], axis='rows')
-
-        # calculate lower and upper 95% PI
-        boot_summary = (boot_results.describe(percentiles=[.05, .95])).T
-        boot_summary['boot_x'] = boot_summary.index
+        # calculate lower and upper 95% PI using numpy directly (avoids pandas describe overhead)
+        boot_summary = pd.DataFrame({
+            'boot_x': new_x,
+            'count':  float(mat.shape[0]),
+            'mean':   mat.mean(axis=0),
+            'std':    mat.std(axis=0, ddof=1),
+            'min':    mat.min(axis=0),
+            '5%':     np.percentile(mat, 5,  axis=0),
+            '50%':    np.percentile(mat, 50, axis=0),
+            '95%':    np.percentile(mat, 95, axis=0),
+            'max':    mat.max(axis=0),
+        })
 
         # calculate the bootstrapped CV
         boot_summary['boot_cv'] = boot_summary['std']/boot_summary['mean']
@@ -517,20 +540,15 @@ def build_plots(peptide, x, y, model_results, boot_results, num_bootreps, std_mu
     df = pd.DataFrame({"curvepoint": x, "area": y})
 
     # Instead of direct CV, match prediction boostrap and take CV of resampled _means_
-    means = pd.DataFrame()
+    # Collect per-rep means into a list, then concat once (avoids O(n²) concat-in-loop)
+    boot_means_list = []
     for i in range(num_bootreps):
-        # resample
         resampled_df = df.sample(n=len(df), replace=True)
-
-        # get the mean for each point
-        resampled_means = resampled_df.groupby("curvepoint").mean()
-
-        # append to frame
-        means = pd.concat([means, resampled_means], axis="rows")
+        boot_means_list.append(resampled_df.groupby("curvepoint")["area"].mean())
 
     # Compute the average/std across boostrapped means for each point
-    groups = means.groupby("curvepoint").agg({'area': ["mean", "std"]})
-    cv = groups[("area", "std")] / groups[("area", "mean")]
+    means = pd.concat(boot_means_list, axis=1).T
+    cv = means.std(axis=0) / means.mean(axis=0)
 
     plt.scatter(cv.index, cv, marker="o", color="tab:blue", label="_nolegend_")
 
@@ -626,6 +644,7 @@ def process_peptide(bootreps, cv_thresh, output_dir, peptide, plot_or_not, std_m
 
 
 def main():
+    _default_threads = max(1, (os.cpu_count() or 1) - 2)
     # usage statement and input descriptions
     parser = argparse.ArgumentParser(
         description='A  model for fitting calibration curve data. Takes calibration curve measurements as input, and \
@@ -664,7 +683,9 @@ def main():
     parser.add_argument('--model', default='auto', choices=['auto', 'piecewise'], 
                         help='Specify which model to use for LOQ fitting, auto (per peptide) or the original piecewise fit. \
                                 Default is auto (best AIC).')
-
+    parser.add_argument('--n_threads', default=_default_threads, type=int,
+                        help='number of worker processes for parallel peptide processing '
+                             f'(default: cpu_count - 2 = {_default_threads}; set to -1 to use all CPUs)')
 
 
     # parse arguments from command line
@@ -681,6 +702,7 @@ def main():
     plot_or_not = args.plot
     verbose = args.verbose
     model_type = args.model
+    n_threads = args.n_threads if args.n_threads != -1 else None  # None → ProcessPoolExecutor uses all CPUs
 
     # read in the data
     quant_df_melted = read_input(raw_file, col_conc_map_file)
@@ -695,7 +717,7 @@ def main():
                                         'stndev_noise'])
 
     # and awwaayyyyy we go~
-    with ProcessPoolExecutor() as exec:
+    with ProcessPoolExecutor(max_workers=n_threads) as exec:
         # First, submit each peptide as a job to the executor
         futures = []
         for peptide, subset in quant_df_melted.groupby('peptide'):

--- a/bin/loq_by_cv.py
+++ b/bin/loq_by_cv.py
@@ -17,7 +17,7 @@ def read_input(filename, col_conc_map_file):
         sys.stdout.write("Input identified as EncyclopeDIA *.elib.peptides.txt filetype.\n")
 
         df = pd.read_table(filename, sep=None, engine="python")  # read in the table
-        df = df.drop(['numFragments', 'Protein'], 1)  # make a quantitative df with just curve points and peptides
+        df = df.drop(['numFragments', 'Protein'], axis=1)  # make a quantitative df with just curve points and peptides
         col_conc_map = pd.read_csv(col_conc_map_file, sep=',', engine="python")
         df = df.rename(columns=col_conc_map.set_index('filename')['concentration'])  # map filenames to concentrations
         df = df.rename(columns={'Peptide': 'peptide'})  # rename the peptide column
@@ -47,7 +47,7 @@ def read_input(filename, col_conc_map_file):
             df_melted.rename(columns={'Peptide Sequence': 'peptide'}, inplace=True)
             df_melted.rename(columns={'concentration': 'curvepoint'}, inplace=True)
 
-            df_melted['area'].fillna(0, inplace=True)  # replace NA with 0
+            df_melted['area'] = df_melted['area'].fillna(0)  # replace NA with 0
 
     # convert the curve points to numbers so that they sort correctly
     df_melted['curvepoint'] = pd.to_numeric(df_melted['curvepoint'])
@@ -88,54 +88,27 @@ def calculate_oneCV(subset_df):
 def calculate_LOQ_byCV(df):
     sys.stderr.write("Calculating LOQ by %CV.\n")
 
-    # initialize empty data frames to store results
-    cv_colnames = ['peptide', 'curvepoint', '%CV']
-    peptideCVs = pd.DataFrame(columns=cv_colnames)
+    # compute CV for every (peptide, curvepoint) group using pandas C-level aggregations
+    # (ddof=1 matches calculate_oneCV; groupby std defaults to ddof=1)
+    grp = df.groupby(['peptide', 'curvepoint'], sort=False)['area']
+    _means = grp.mean()
+    _stds  = grp.std(ddof=1)
+    _cv    = (_stds / _means).where(_means != 0, other=np.nan)
+    peptideCVs = _cv.rename('%CV').reset_index()
 
-    loq_colnames = ['peptide', 'loq']
-    peptideLOQs = pd.DataFrame(columns=loq_colnames)
+    # find LOQ: lowest curvepoint (> 0) with CV <= 20% for each peptide
+    good_cv_rows = peptideCVs[(peptideCVs['%CV'] <= 0.2) & (peptideCVs['curvepoint'] > 0)]
+    peptideLOQs = (
+        good_cv_rows.sort_values('curvepoint')
+                    .groupby('peptide', sort=False)['curvepoint']
+                    .first()
+                    .reset_index()
+                    .rename(columns={'curvepoint': 'loq'})
+    )
 
-    # iterate through each peptide
-    for peptide in tqdm(df.peptide.unique()):
-
-        # subset the dataframe for this precursor
-        subset_df = df.loc[(df['peptide'] == peptide)]
-
-        # empty dataframe to store this peptides CVs
-        this_peptides_CVs = pd.DataFrame(columns=cv_colnames)
-
-        # calculate points' CV
-        for point in subset_df['curvepoint'].unique():
-
-            # subset the subset dataframe for each curve point
-            subsubset_df = subset_df.loc[(subset_df['curvepoint']) == point]
-
-            # calculate the CV for the curve point
-            cv = calculate_oneCV(subsubset_df)
-
-            # store the peptide, curve point, & %cv as dataframe
-            new_row = [peptide, point, cv]
-            new_df_row = pd.DataFrame([new_row], columns=cv_colnames)
-            peptideCVs = peptideCVs.append(new_df_row)
-            this_peptides_CVs = this_peptides_CVs.append(new_df_row)
-
-        # sort by curvepoint
-        this_peptides_CVs = this_peptides_CVs.sort_values(by='curvepoint', ascending=True)
-        curvepoints = this_peptides_CVs['curvepoint'].unique().tolist()
-        curvepoints = [x for x in curvepoints if x > 0]
-
-        # move down the curve points from lowest to highest, checking the
-        # cv at each to find the lowest point with <= 20% CV
-        loq = np.nan
-        for i in curvepoints:
-            if this_peptides_CVs.loc[this_peptides_CVs['curvepoint'] == i, '%CV'].iloc[0] <= 0.2:
-                loq = i  # loq is lowest point with <= 20% cv
-                break
-
-        # write the 20% cv loq to dataframe
-        new_loq_row = pd.DataFrame([[peptide, loq]], columns=loq_colnames)
-        peptideLOQs = peptideLOQs.append(new_loq_row)
-
+    # peptides with no good-CV point get NaN loq
+    all_peps = pd.DataFrame({'peptide': df['peptide'].unique()})
+    peptideLOQs = all_peps.merge(peptideLOQs, on='peptide', how='left')
 
     peptideLOQs.to_csv(os.path.join(output_dir, "./loqsbycv.csv"), index=False)
     peptideCVs.to_csv(os.path.join(output_dir, "./peptidecvs.csv"), index=False)
@@ -257,9 +230,10 @@ def make_plot(df):
     # force y axis ticks to be scientific notation so the plot is prettier (x is already semilog)
 
     plt.xlim(xmin=min(x)-max(x)*0.01)  # anchor x and y to 0-ish.
-    if len(cv) > 0:
+    cv_max = cv.max()
+    if len(cv) > 0 and np.isfinite(cv_max) and cv_max > 0:
         plt.ylim(ymin=-0.01,
-                 ymax=(max(cv)*1.05))
+                 ymax=(cv_max*1.05))
 
     # save the figure
     # add legend with LOD and LOQ values
@@ -291,8 +265,8 @@ if __name__ == "__main__":
                         help='use a single-point multiplier associated with the curve data peptides')
     parser.add_argument('--output_path', default=os.getcwd(), type=str,
                         help='specify an output path for figures of merit and plots (default=current directory)')
-    parser.add_argument('--plot', default=True, type=bool,
-                        help='create individual calibration curve plots for each peptide (default=True)')
+    parser.add_argument('--plot', default='y', type=str,
+                        help='create individual calibration curve plots for each peptide (y/n, default=y)')
 
     # parse arguments from command line
     args = parser.parse_args()
@@ -313,7 +287,7 @@ if __name__ == "__main__":
     loq_byCV_df = calculate_LOQ_byCV(quant_df_melted)
 
     # plot if requested
-    if plot_or_nah == True:
+    if plot_or_nah == 'y':
         sys.stderr.write("Building plots.\n")
         for peptide in tqdm(loq_byCV_df.peptide.unique()):
             make_plot(loq_byCV_df.loc[(loq_byCV_df['peptide'] == peptide)])


### PR DESCRIPTION
Hi @lindsaypino and all,

This PR updates `calculate_loq.py` and `loq_by_cv.py` with bug fixes, pandas 2.x compatibility, and performance improvements. We use these scripts regularly and wanted to pass our changes upstream.

Benchmark scripts and figures are attached for reference but are not part of the patch.

### Changes

Full list with details: [CHANGES.txt](https://github.com/user-attachments/files/25804735/CHANGES.txt)

**Bug fixes**

- Corrected LOQ formula
- Changed noise std to `ddof=1` (see note below)
- Prevented crashes on zero-mean peptides
- Fixed ignored `--plot` flag
- Ensured deterministic behaviour with multiple workers

**Pandas 2.x compatibility**

- Replaced deprecated `DataFrame.append`
- Added `axis=` keyword where required
- Removed inplace `fillna` calls

**Performance**

- Vectorised group-by in `loq_by_cv.py`
- Rewrote `bootstrap_many()` for ~25–30% speedup and comparible memory usage

**New options**

- `--n_threads` to cap parallel workers (default = cpu−2)
- Warning when concentration map contains blank entries (should address -> #12 )

---

### Benchmarking and Validation

I tried to ensure my version doesn't break things too much, for that I have run a simple benchmarking and added bunch of unit tests. 
- Benchmark: 
  - [run_benchmark.py](https://github.com/user-attachments/files/25804753/run_benchmark.py): Compare to test-data in the repo
  - [simulate_and_scale.py](https://github.com/user-attachments/files/25804752/simulate_and_scale.py): Simulated data to benhmarking speed and memory usage with increasing peptide x bootstraps.
- Unit-tests: 
  - [conftest.py](https://github.com/user-attachments/files/25805076/conftest.py)
  - [test_calculate_loq_core.py](https://github.com/user-attachments/files/25805077/test_calculate_loq_core.py)
  - [test_edge_cases.py](https://github.com/user-attachments/files/25805078/test_edge_cases.py): Additional edge-case tests for new warnings, threading, and previously hidden failure modes
  - [test_loq_by_cv_core.py](https://github.com/user-attachments/files/25805080/test_loq_by_cv_core.py)
  - 92 existing tests pass (2 xfail retained)
  - Pairwise LOD/LOQ comparison against old code on the original dataset: results match within float tolerance when ddof=0 is used

This is the comparing both versions where you can see at the LOQ there is a peptide very off from the line, this is caused by the ddof=0 vs ddof=1 difference. 
<img width="2234" height="591" alt="real_data_benchmark" src="https://github.com/user-attachments/assets/fd75ba33-fdbf-490b-b8d2-9e12c00267f1" />

Additionally you can see the detectability shows 16 vs 15 making ddof=1 losing one of the peptides as undetected on piecewise mode specifically. 
<img width="1633" height="593" alt="model_comparison" src="https://github.com/user-attachments/assets/3856d2e3-e036-4de0-937b-c1107e661398" />

### Note on `ddof=0` → `ddof=1`

Original code uses `np.std(..., ddof=0)` (population std). We changed to `ddof=1` (sample std) since the noise-segment observations are a sample, not the full population. `ddof=0` underestimates σ, which can make LOQ estimates slightly anti-conservative.

The difference is ~6% at n=9 and &lt;3% at n≥20.

If `ddof=0` is expected or required for backward-compatibility, happy to revert or make it a `--ddof` flag.

Finally, what I think will be quite  a difference, especially in a real-life data where we deal with tons of peptides, this new versions make quite bit of a difference: 

<img width="2234" height="593" alt="scale_benchmark" src="https://github.com/user-attachments/assets/381909a4-fa2a-4944-96a1-5a39503cef6a" />

Thanks for your time — feel free to request any revisions or additional splits. We've been using this method routinely and wanted to contribute back rather than maintain changes separately.

Enes K. Ergin